### PR TITLE
Position Arguments

### DIFF
--- a/roots-css/positions.styl
+++ b/roots-css/positions.styl
@@ -1,11 +1,47 @@
 // Direct port from the brilliant utility for nib
 // https://github.com/visionmedia/nib/blob/master/lib/nib/positions.styl
 
+-keys(props)
+
+  props = arguments if length(arguments) > 1
+  keys  = ()
+
+  for prop in props
+    unless prop is a 'unit'
+      push(keys, prop)
+
+  return keys
+
+-vals(props)
+
+  props  = arguments if length(arguments) > 1
+  vals   = ()
+  length = length(props)
+
+  for prop, i in props
+    if prop is a 'unit'
+        push(vals, prop)
+    else
+      if previous is defined
+        unless previous is a 'unit'
+          push(vals,0)
+
+      if (i+1) == length
+        push(vals,0)
+
+    previous = prop
+
+  return vals
+
 -pos(type, args)
-  i = 0
+
+  keys = -keys(args)
+  vals = -vals(args)
+
   position: unquote(type)
-  {args[i]}: args[i + 1] is a 'unit' ? args[i += 1] : 0
-  {args[i += 1]}: args[i + 1] is a 'unit' ? args[i += 1] : 0
+
+  for key, i in keys
+    {key}: vals[i];
 
 /*
  * Position utility.


### PR DESCRIPTION
I noticed the fix for adding more arguments to the position mixins, but if you leave any blank then (null) is output. I have fixed this by iterating over the arguments supplied to the mixins.
