### PR TITLE
global-reset() tweaks

### DIFF
--- a/roots-css/reset.styl
+++ b/roots-css/reset.styl
@@ -71,8 +71,6 @@ global-reset()
     border: none
   body
     line-height: 1
-    color: black
-    background: white
   ol, ul
     list-style: none
   // table reset
@@ -102,7 +100,7 @@ global-reset()
   summary
     margin: 0
     padding: 0
-    border: 0
+    border: none
     outline: 0
     display: block
   audio


### PR DESCRIPTION
For the HTML5 elements the border rule needed to be 'none' rather than '0'. Also nixed the background and color rules on body so they're inheritable.
