### PR TITLE
Missing '-' on vendor prefixes

### DIFF
--- a/roots-css/vendor.styl
+++ b/roots-css/vendor.styl
@@ -192,8 +192,8 @@ animation()
 // Webkit values: http://code.google.com/p/webkit-mirror/source/browse/Source/WebCore/css/CSSValueKeywords.in?spec=svnf1aea559dcd025a8946aa7da6e4e8306f5c1b604&r=63c7d1af44430b314233fea342c3ddb2a052e365#584
 
 appearance()
-  webkit-appearance: arguments
-  moz-appearance: arguments
+  -webkit-appearance: arguments
+  -moz-appearance: arguments
 
 // Mixin: background-appearance-x and y
 // In case you want to use an unsupported background-position property, this


### PR DESCRIPTION
Added missing '-' on vendor prefixes for appearance mixin
