### PR TITLE
Extracted settings into its own file

### DIFF
--- a/roots-css/index.styl
+++ b/roots-css/index.styl
@@ -1,56 +1,8 @@
 // -------------------------------------------------------
-// Global settings - adjust these to your heart's desire
-// -------------------------------------------------------
-
-// font options (add your own!)
-helvetica-neue = "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif
-helvetica = "Helvetica Neue", Helvetica, Arial, sans-serif
-georgia = Georgia, Cambria, "Times New Roman", Times, serif
-lucidia-grande = "Lucida Grande", Tahoma, Verdana, Arial, sans-serif
-monospace = unquote("'Bitstream Vera Sans Mono', Consolas, Courier, monospace")
-verdana = Verdana, Geneva, sans-serif
-
-// default font stack
-font-stack = helvetica-neue
-font-size = 15
-font-color = #555
-
-// colors
-red = #B44326
-orange = #F2A34F
-yellow = #F8CA5C
-green = #7FC028
-light-blue = #52D7FE
-blue = #00a6fc
-purple = #8E48C2
-white = #fff
-black = #272727
-
-// default color
-default-color = blue
-
-// text highlight color
-highlight-color = blue
-
-// vendor prefixes
-vendors = webkit moz o ms official
-
-// custom image base path for roots mixins
-img-path = ''
-
-// progressive internet explorer (http://css3pie.com/)
-pie-enabled = false
-pie-path = '/pie.htc'
-
-// grid system settings (http://semantic.gs)
-column-width = 60px
-gutter-width = 20px
-columns = 12
-
-// -------------------------------------------------------
 // Importing all the files we need
 // -------------------------------------------------------
 
+@import 'settings'
 @import 'reset'
 @import 'vendor'
 @import 'utilities'

--- a/roots-css/settings.styl
+++ b/roots-css/settings.styl
@@ -1,0 +1,49 @@
+// -------------------------------------------------------
+// Global settings - adjust these to your heart's desire
+// -------------------------------------------------------
+
+// font options (add your own!)
+helvetica-neue = "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif
+helvetica = "Helvetica Neue", Helvetica, Arial, sans-serif
+georgia = Georgia, Cambria, "Times New Roman", Times, serif
+lucidia-grande = "Lucida Grande", Tahoma, Verdana, Arial, sans-serif
+monospace = unquote("'Bitstream Vera Sans Mono', Consolas, Courier, monospace")
+verdana = Verdana, Geneva, sans-serif
+
+// default font stack
+font-stack = helvetica-neue
+font-size = 15
+font-color = #555
+
+// colors
+red = #B44326
+orange = #F2A34F
+yellow = #F8CA5C
+green = #7FC028
+light-blue = #52D7FE
+blue = #00a6fc
+purple = #8E48C2
+white = #fff
+black = #272727
+
+// default color
+default-color = blue
+
+// text highlight color
+highlight-color = blue
+
+// vendor prefixes
+vendors = webkit moz o ms official
+
+// custom image base path for roots mixins
+img-path = ''
+
+// progressive internet explorer (http://css3pie.com/)
+pie-enabled = false
+pie-path = '/pie.htc'
+
+// grid system settings (http://semantic.gs)
+column-width = 60px
+gutter-width = 20px
+columns = 12
+


### PR DESCRIPTION
I extracted the settings on `index.styl` to its own file, so that it looks similar to _settings.styl on roots. This way it is also easier to copy this file when using roots-css as a library on a non-roots project.

This is what I meant in #20

What do you think?
