### PR TITLE
Fixes to the media helper

### DIFF
--- a/roots-css/utilities.styl
+++ b/roots-css/utilities.styl
@@ -207,9 +207,9 @@ media(margin = 10px)
   left-margin = margin
   right-margin = margin
 
-  if length(margin) > 1
-    left-margin = margin[0]
-    right-margin = margin[1]
+  if length(arguments) > 1
+    left-margin = arguments[0]
+    right-margin = arguments[1]
 
   overflow: hidden
   zoom: 1


### PR DESCRIPTION
Make the media helpers siblings act as inline blocks because block elements may have been used.
