### PR TITLE
Fix: malfunctioning grid() call

### DIFF
--- a/axis/grid.styl
+++ b/axis/grid.styl
@@ -105,7 +105,7 @@ cf = clearfix
 grid()
   *
     box-sizing: border-box
-    *behavior: url(box-sizing-path) if box-sizing-enabled
+    behavior: url(box-sizing-path) if box-sizing-enabled
   html
     overflow-y: scroll
     overflow-x: hidden


### PR DESCRIPTION
Whenever calling `grid()` only `box-sizing: border-box` would get called, because the behavior tag was causing things to block. Now all styles get loaded properly whenever calling `grid()`.
