### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axis-css",
   "description": "css library built on stylus",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "git://github.com/jenius/axis.git"


### PR DESCRIPTION
Forgot to do this when I updated the background color stuff for gradients. Please bump version and `npm publish` so the people can rejoice!
