### PR TITLE
Fix to converting base font size to percentage

### DIFF
--- a/axis/typography.styl
+++ b/axis/typography.styl
@@ -314,15 +314,17 @@ hyphenation()
 // ex. +base
 
 base(fonts = font-stack, size = font-size, color = font-color)
+  html, body
+    font-size: unit(size, px)
+    font-size: unit((size/16)*100, "%")
+
   body
     font-family: fonts
-    font-size: unit(size, px)
-    font-size: unit(size*6.46, "%")
     color: color
     -webkit-font-smoothing: antialiased
     -webkit-text-size-adjust: 100%
     -ms-text-size-adjust: 100%
-    font-size-adjust:auto
+    font-size-adjust: auto
 
 // Additive Mixin: Headers
 // WARNING: Creates classes in your css and styles them - not to be used inside an element.


### PR DESCRIPTION
Fix's calculation for converting base font-size to percentage, also moves initial font-size declaration to the `html` and `body` element for later rem calculations.
