### PR TITLE
remove literal-join call in bg-retina mixin

### DIFF
--- a/axis/utilities.styl
+++ b/axis/utilities.styl
@@ -52,7 +52,7 @@ bg-retina(path, width, height, args...)
   args = unquote('no-repeat') unless args
   background: url(img-path path) args
   size: width height
-  background-size: literal-join('', width height)
+  background-size: width height
 
 // Mixin: Bold
 // It's just faster to type +bold than font-weight: bold


### PR DESCRIPTION
Hey @jenius, I'm not really sure what `literal-join` is for, but I couldn't find the source and it doesn't seem to be defined as a stylus mixin/function in axis. Stylus just compiles the full function name though. See screenshot below.

![](https://i.cloudup.com/I76FBpcZHA.png)
