### PR TITLE
border fix for simple-button

### DIFF
--- a/axis/buttons.styl
+++ b/axis/buttons.styl
@@ -63,7 +63,7 @@ $button(color = default-color, size = "medium", textColor = null)
   text-align: center
   text-decoration: none
   display: inline-block
-
+  border none
   &:hover, &:focus
     background-color: darken(color, 5%)
     color: darken(textColor, 3%)

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -370,6 +370,7 @@ textarea.error:focus {
   text-align: center;
   text-decoration: none;
   display: inline-block;
+  border: none;
 }
 .btn-simple:hover,
 .btn-simple:focus {

--- a/test/fixtures/buttons/button.css
+++ b/test/fixtures/buttons/button.css
@@ -11,6 +11,8 @@
   text-align: center;
   text-decoration: none;
   display: inline-block;
+  border: none;
+
 }
 .button:hover,
 .button:focus {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2446638/3214285/ff2490ac-efab-11e3-8c2e-db79dcac9ebc.png)
Because div.btn is used in docs demo - default buttons styles are not applying.
