### PR TITLE
hyphenation invalid css fix

### DIFF
--- a/axis/typography.styl
+++ b/axis/typography.styl
@@ -292,15 +292,15 @@ blockquo = $blockquote
 // Taken from http://www.newnet-soft.com/blog/csstypography
 
 hyphenation()
-  -ms-word-break: break-all
-  word-break:     break-all
-  word-break:     break-word // webkit
-
-  hyphens: auto // none, auto, <number>
-
-  -webkit-hyphenate-before: 2
-  -webkit-hyphenate-after:  3
-  hyphenate-lines:          3
+    -ms-word-break: break-all
+    word-break:     break-all
+    word-break:     break-word // webkit
+  
+    hyphens: auto // none, auto, <number>
+  
+    -webkit-hyphenate-before: 2
+    -webkit-hyphenate-after:  3
+    hyphenate-lines:          3
 
 // -----------------------------------------------------
 // Mixins that add styles to tags on your page actively
@@ -385,7 +385,6 @@ bold-italic()
 typography()
   bold-italic()
   headers()
-  hyphenation()
   lists()
   text-selection()
 
@@ -400,3 +399,6 @@ typography()
 
   blockquote
     blockquo()
+  
+  .hyphenation
+    hyphenation()

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -72,16 +72,7 @@ h6 {
   line-height: 1.6em;
   text-transform: uppercase;
 }
--ms-word-break: break-all;
-word-break: break-all;
-word-break: break-word;
--webkit-hyphens: auto;
--moz-hyphens: auto;
--ms-hyphens: auto;
-hyphens: auto;
--webkit-hyphenate-before: 2;
--webkit-hyphenate-after: 3;
-hyphenate-lines: 3;
+
 ::-moz-selection {
   background: #0074d9;
   color: #494949;
@@ -146,6 +137,20 @@ blockquote > footer:before,
 blockquote > figcaption:before {
   content: '\2014';
 }
+
+.hyphenation {
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  -webkit-hyphenate-before: 2;
+  -webkit-hyphenate-after: 3;
+  hyphenate-lines: 3;
+}
+
 input[type='email'],
 input[type='number'],
 input[type='password'],


### PR DESCRIPTION
hyphenation mixin was producing illegal css, without selectors and curly bracers.

moved it to class `.hyphenation`, like you did in [corresponding test for this mixin](../blob/master/test/fixtures/typography/hyphenation.styl)
