### PR TITLE
Update test for base() fix

### DIFF
--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -1,5 +1,4 @@
-html,
-body {
+html {
   font-size: 16px;
   font-size: 100%;
 }


### PR DESCRIPTION
The font-size property was being applied to both the html and body elements causing the % size reduction to occur twice, such that when font-size was set to 14px the actual type size was ~12px.
