### PR TITLE
add index.styl for easy inclusion

### DIFF
--- a/index.styl
+++ b/index.styl
@@ -1,0 +1,1 @@
+@import 'axis/'


### PR DESCRIPTION
nib has an [`index.styl`](https://github.com/visionmedia/nib/blob/master/index.styl) file in the home directory so that you can easily include it with `@import 'nib'` rather than, say, `@import 'nib/lib/nib/'. Made things more convenient for me in a current project where using npm isn't clean or necessary (on harp.io).
