### PR TITLE
vertical-rhytm and typography fix for small element

### DIFF
--- a/axis/reset.styl
+++ b/axis/reset.styl
@@ -74,6 +74,17 @@ normalize-css()
   h6
     font-size: 0.67em
     margin: 2.33em 0
+  h1
+  h2
+  h3
+  h4
+  h5
+  h6
+  p
+  blockquote
+  figcaption
+    small
+      line-height: 1
 
   abbr[title]
     border-bottom: 1px dotted

--- a/axis/vertical-rhythm.styl
+++ b/axis/vertical-rhythm.styl
@@ -285,6 +285,17 @@ baseline-normalize()
     adjust-font-size-to: h6-font-size
     leader: 1, h6-font-size
     trailer: 1, h6-font-size
+  h1
+  h2
+  h3
+  h4
+  h5
+  h6
+  p
+  blockquote
+  figcaption
+    small
+      line-height: 1
 
   abbr[title]
     border-bottom: 1px dotted


### PR DESCRIPTION
Hi!
fix for vertical-rhythm issue with `small` element.
`small` without forced line-height or vertical-align makes block-level element a little bit bigger then it must be with its line-height :(

checked in latest chrome, firefox. also bootstrap got the same fix for small in headings.
