### PR TITLE
rhythm tables, vr fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+[*.jade]
+trim_trailing_whitespace = false

--- a/axis/tables.styl
+++ b/axis/tables.styl
@@ -5,44 +5,73 @@
 
 // TODO: Add options to customize colors
 
-$table(border = true, striped = true, condensed = false)
-
+$table(border = true, striped = true, condensed = false, rhythm = false)
   max-width: 100%
   border-collapse: collapse
   border-spacing: 0
   width: 100%
-  margin-bottom: 18px
+  if rhythm
+    if border
+      trailer(1, border: 1)
+      leader(1, border: 1)
+    else
+      trailer(1)
+      leader(1)
+
+  else
+    margin-bottom: 18px
 
   th, td
-    padding: 8px
-    line-height: 18px
+    if rhythm
+      if condensed
+        padding 4px
+        padding-trailer(.25)
+        if border
+          leading-border(lines: .25)
+        else
+          padding-leader(.25)
+        adjust-leading-to(.5)
+      else
+        padding 8px
+        padding-trailer(.5)
+        if border
+          leading-border(lines: .5)
+        else
+          padding-leader(.5)
+        adjust-leading-to(1)
+    else
+      if condensed
+        padding: 4px 5px
+      else
+        padding: 8px
+        line-height: 18px
+        border-top: 1px solid
+    border-color #ddd
     text-align: left
     vertical-align: top
-    border-top: 1px solid #ddd
 
   th
     font-weight: bold
 
   thead th
     vertical-align: bottom
-
-  thead:first-child tr th
-  thead:first-child tr td
-    border-top: 0
+  if border
+    if not rhythm
+      thead:first-child tr th
+      thead:first-child tr td
+        border-top: 0
 
   tbody + tbody
     border-top: 2px solid #ddd
 
-  if condensed
-    th, td
-      padding: 4px 5px
 
   if border
     border: 1px solid #ddd
     border-collapse: separate
     *border-collapse: collapsed
     border-radius: 4px
-    
+
+
     th + th, td + td, th + td, td + th
       border-left: 1px solid #ddd
 
@@ -66,6 +95,8 @@ $table(border = true, striped = true, condensed = false)
     thead:last-child tr:last-child th:last-child
     tbody:last-child tr:last-child td:last-child
       border-radius: 0 0 4px 0
+  else
+    border 0
 
   if striped
     tbody tr:nth-child(odd) td
@@ -80,6 +111,6 @@ $table(border = true, striped = true, condensed = false)
 // WARNING: Creates classes in your css and styles them - not to be used inside an element.
 // Makes tables look awesome by default. Highly recommended if you have tables on your site at all.
 
-tables()
+tables(border = true, striped = true, condensed = false, rhythm = false)
   table
-    $table()
+    $table(border, striped, condensed, rhythm)

--- a/axis/vertical-rhythm.styl
+++ b/axis/vertical-rhythm.styl
@@ -86,15 +86,17 @@ establish-baseline(fs = base-font-size)
 // TODO: Make a better version of this
 debug-vertical-alignment()
   background-image: url('http://basehold.it/i/' + unit(base-line-height, ''))
-
+-check-relative(font-size)
+  if not relative-font-sizing
+    if unit(font-size) is not 'px'
+      warn('relative-font-sizing is false but a relative font size was passed to adjust-font-size-to')
 // Adjust a block to have a different font size and line height to maintain the
 // rhythm. $lines specifies how many multiples of the baseline rhythm each line
 // of this font should use up. It does not have to be an integer, but it
 // defaults to the smallest integer that is large enough to fit the font.
 // Use $from-size to adjust from a font-size other than the base font-size.
 adjust-font-size-to(to-size, lines = -lines-for-font-size(to-size), from-size = base-font-size)
-  if (not relative-font-sizing) and (from-size is not base-font-size)
-    warn('relative-font-sizing is false but a relative font size was passed to adjust-font-size-to')
+  -check-relative(from-size)
   font-size: font-unit * (to-size / from-size)
   adjust-leading-to: lines, relative-font-sizing ? to-size : base-font-size
 
@@ -107,14 +109,18 @@ adjust-leading-to(lines, font-size = base-font-size)
 
 // @public function - Calculate rhythm units.
 -rhythm(lines = 1, font-size = base-font-size, offset = 0)
-  if (not relative-font-sizing) and (font-size is not base-font-size)
-    warn('relative-font-sizing is false but a relative font size was passed to the rhythm function')
-  rhythm = font-unit * (lines * base-line-height - offset) / font-size
+  -check-relative(font-size)
+  if not relative-font-sizing
+    font-unit = font-size
+  rhythm = font-unit * (lines * base-line-height) / font-size
+  if offset
+    offset = unit(offset/font-size, relative-font-sizing ? 'em' : 'px')
   // Round the pixels down to nearest integer.
   if unit(rhythm) is 'px'
-    rhythm = floor(rhythm)
+    rhythm = floor(rhythm - offset)
+  else
+    rhythm = rhythm - offset
   return rhythm
-
 // @private Function - Calculate the minimum multiple of rhythm units needed to contain the font-size.
 -lines-for-font-size(font-size)
   lines = round-to-nearest-half-line ? ceil(2 * font-size / base-line-height) / 2 : ceil(font-size / base-line-height)
@@ -123,65 +129,66 @@ adjust-leading-to(lines, font-size = base-font-size)
   return unit(lines, '')
 
 // Apply leading whitespace. The $property can be margin or padding.
-leader(lines = 1, font-size = base-font-size, property = margin)
-  {property}-top: -rhythm(lines, font-size)
+leader(lines = 1, font-size = base-font-size, property = margin, border = 0)
+  {property}-top: -rhythm(lines, font-size, offset: border)
 
 // Apply leading whitespace as padding.
-padding-leader(lines = 1, font-size = base-font-size)
-  padding-top: -rhythm(lines, font-size)
+padding-leader(lines = 1, font-size = base-font-size, border = 0)
+  padding-top: -rhythm(lines, font-size, offset: border)
 
 // Apply leading whitespace as margin.
-margin-leader(lines = 1, font-size = base-font-size)
-  margin-top: -rhythm(lines, font-size)
+margin-leader(lines = 1, font-size = base-font-size, border = 0)
+  margin-top: -rhythm(lines, font-size, offset: border)
 
 // Apply trailing whitespace. The $property can be margin or padding.
-trailer(lines = 1, font-size = base-font-size, property = margin)
-  {property}-bottom: -rhythm(lines, font-size)
+trailer(lines = 1, font-size = base-font-size, property = margin, border = 0)
+  {property}-bottom: -rhythm(lines, font-size, offset: border)
 
 // Apply trailing whitespace as padding.
-padding-trailer(lines = 1, font-size = base-font-size)
-  padding-bottom: -rhythm(lines, font-size)
+padding-trailer(lines = 1, font-size = base-font-size, border = 0)
+  padding-bottom: -rhythm(lines, font-size, offset: border)
 
 // Apply trailing whitespace as margin.
-margin-trailer(lines = 1, font-size = base-font-size)
-  margin-bottom: -rhythm(lines, font-size)
+margin-trailer(lines = 1, font-size = base-font-size, border = 0)
+  margin-bottom: -rhythm(lines, font-size, offset: border)
 
 // Shorthand mixin to apply whitespace for top and bottom margins and padding.
-rhythm(l = 0, pl = 0, pt = 0, t = 0, font-size = base-font-size)
-  leader: l, font-size
-  padding-leader: pl, font-size
-  padding-trailer: pt, font-size
-  trailer: t, font-size
+rhythm(l = 0, pl = 0, pt = 0, t = 0, font-size = base-font-size, plb = 0, ptb = 0, lb = 0, tb = 0, border = 0 )
+
+  leader(l, font-size, offset: (lb ? lb : border))
+  padding-leader(pl, font-size, offset: (plb ? plb : border))
+  padding-trailer(pt, font-size, offset: (ptb ? ptb : border))
+  trailer(t, font-size, offset: (tb ? tb : border))
 
 // Apply a border and whitespace to any side without destroying the vertical
 // rhythm. The whitespace must be greater than the width of the border.
-apply-side-rhythm-border(side, w = 1px, lines = 1, font-size = base-font-size, bs = default-rhythm-border-style)
-  if (not relative-font-sizing) and (font-size is not base-font-size)
-    warn('relative-font-sizing is false but a relative font size was passed to apply-side-rhythm-border')
+apply-side-rhythm-border(side, w = 1px, lines = 1, font-size = base-font-size, bs = default-rhythm-border-style, property = padding)
+  -check-relative(font-size)
+  if not relative-font-sizing
+    font-unit = font-size
   border-{side}-style: bs
   border-{side}-width: font-unit * (w / font-size)
-  padding-{side}: -rhythm(lines, font-size, offset = w)
+  {property}-{side}: -rhythm(lines, font-size, offset: w)
 
 // Apply borders and whitespace equally to all sides.
-rhythm-borders(w = 1px, lines = 1, font-size = base-font-size, bs = default-rhythm-border-style)
+rhythm-borders(w = 1px, lines = 1, font-size = base-font-size, bs = default-rhythm-border-style, property = padding)
   if (not relative-font-sizing) and (font-size is not base-font-size)
     warn('relative-font-sizing is false but a relative font size was passed to rhythm-borders')
   border-style: bs
   border-width: font-unit * (w / font-size)
-  padding: -rhythm(lines, font-size, offset = w)
-
+  {property}: -rhythm(lines, font-size, offset: w)
 // Apply a leading border.
-leading-border(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style)
-  apply-side-rhythm-border: top, width, lines, font-size, border-style
+leading-border(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style, property = padding)
+  apply-side-rhythm-border(top, width, lines, font-size, border-style, property: property)
 
 // Apply a trailing border.
-trailing-border(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style)
-  apply-side-rhythm-border: bottom, width, lines, font-size, border-style
+trailing-border(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style, property = padding)
+  apply-side-rhythm-border(bottom, width, lines, font-size, border-style, property: property)
 
 // Apply both leading and trailing borders.
-horizontal-borders(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style)
-  leading-border: width, lines, font-size, border-style
-  trailing-border: width, lines, font-size, border-style
+horizontal-borders(width = 1px, lines = 1, font-size = base-font-size, border-style = default-rhythm-border-style, property = padding)
+  leading-border(width, lines, font-size, border-style, property: property)
+  trailing-border(width, lines, font-size, border-style, property: property)
 
 // ---------------------------------------------
 // @private Mixin - Internal Baseline Normalize
@@ -308,8 +315,7 @@ baseline-normalize()
     font-style: italic
 
   hr
-    -moz-box-sizing: content-box
-    box-sizing: content-box
+
     height: 0
 
   mark
@@ -448,5 +454,4 @@ baseline-normalize()
     vertical-align: top
 
   table
-    border-collapse: collapse
-    border-spacing: 0
+    $table(rhythm: true)

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -473,9 +473,10 @@ table th,
 table td {
   padding: 8px;
   line-height: 18px;
+  border-top: 1px solid;
+  border-color: #ddd;
   text-align: left;
   vertical-align: top;
-  border-top: 1px solid #ddd;
 }
 table th {
   font-weight: bold;

--- a/test/fixtures/tables/table-rhythm-condensed.css
+++ b/test/fixtures/tables/table-rhythm-condensed.css
@@ -1,0 +1,68 @@
+.table-rhythm {
+  max-width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
+  margin-bottom: 23px;
+  margin-top: 23px;
+  border: 1px solid #ddd;
+  border-collapse: separate;
+  *border-collapse: collapsed;
+  border-radius: 4px;
+}
+.table-rhythm th,
+.table-rhythm td {
+  padding: 4px;
+  padding-bottom: 6px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  padding-top: 5px;
+  line-height: 12px;
+  border-color: #ddd;
+  text-align: left;
+  vertical-align: top;
+}
+.table-rhythm th {
+  font-weight: bold;
+}
+.table-rhythm thead th {
+  vertical-align: bottom;
+}
+.table-rhythm tbody + tbody {
+  border-top: 2px solid #ddd;
+}
+.table-rhythm th + th,
+.table-rhythm td + td,
+.table-rhythm th + td,
+.table-rhythm td + th {
+  border-left: 1px solid #ddd;
+}
+.table-rhythm thead:first-child tr:first-child th,
+.table-rhythm tbody:first-child tr:first-child th,
+.table-rhythm tbody:first-child tr:first-child td {
+  border-top: 0;
+}
+.table-rhythm thead:first-child tr:first-child th:first-child,
+.table-rhythm tbody:first-child tr:first-child td:first-child {
+  border-radius: 4px 0 0 0;
+}
+.table-rhythm thead:first-child tr:first-child th:last-child,
+.table-rhythm tbody:first-child tr:first-child td:last-child {
+  border-radius: 0 4px 0 0;
+}
+.table-rhythm thead:last-child tr:last-child th:first-child,
+.table-rhythm tbody:last-child tr:last-child td:first-child {
+  border-radius: 0 0 0 4px;
+}
+.table-rhythm thead:last-child tr:last-child th:last-child,
+.table-rhythm tbody:last-child tr:last-child td:last-child {
+  border-radius: 0 0 4px 0;
+}
+.table-rhythm tbody tr:nth-child(odd) td,
+.table-rhythm tbody tr:nth-child(odd) th {
+  background-color: #f9f9f9;
+}
+.table-rhythm tbody tr:hover td,
+.table-rhythm tbody tr:hover th {
+  background-color: #f5f5f5;
+}

--- a/test/fixtures/tables/table-rhythm-condensed.styl
+++ b/test/fixtures/tables/table-rhythm-condensed.styl
@@ -1,0 +1,5 @@
+relative-font-sizing = false
+.table-rhythm
+  $table(rhythm: true, condensed: true)
+
+relative-font-sizing = true

--- a/test/fixtures/tables/table-rhythm.css
+++ b/test/fixtures/tables/table-rhythm.css
@@ -1,0 +1,68 @@
+.table-rhythm {
+  max-width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
+  margin-bottom: 23px;
+  margin-top: 23px;
+  border: 1px solid #ddd;
+  border-collapse: separate;
+  *border-collapse: collapsed;
+  border-radius: 4px;
+}
+.table-rhythm th,
+.table-rhythm td {
+  padding: 8px;
+  padding-bottom: 12px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  padding-top: 11px;
+  line-height: 24px;
+  border-color: #ddd;
+  text-align: left;
+  vertical-align: top;
+}
+.table-rhythm th {
+  font-weight: bold;
+}
+.table-rhythm thead th {
+  vertical-align: bottom;
+}
+.table-rhythm tbody + tbody {
+  border-top: 2px solid #ddd;
+}
+.table-rhythm th + th,
+.table-rhythm td + td,
+.table-rhythm th + td,
+.table-rhythm td + th {
+  border-left: 1px solid #ddd;
+}
+.table-rhythm thead:first-child tr:first-child th,
+.table-rhythm tbody:first-child tr:first-child th,
+.table-rhythm tbody:first-child tr:first-child td {
+  border-top: 0;
+}
+.table-rhythm thead:first-child tr:first-child th:first-child,
+.table-rhythm tbody:first-child tr:first-child td:first-child {
+  border-radius: 4px 0 0 0;
+}
+.table-rhythm thead:first-child tr:first-child th:last-child,
+.table-rhythm tbody:first-child tr:first-child td:last-child {
+  border-radius: 0 4px 0 0;
+}
+.table-rhythm thead:last-child tr:last-child th:first-child,
+.table-rhythm tbody:last-child tr:last-child td:first-child {
+  border-radius: 0 0 0 4px;
+}
+.table-rhythm thead:last-child tr:last-child th:last-child,
+.table-rhythm tbody:last-child tr:last-child td:last-child {
+  border-radius: 0 0 4px 0;
+}
+.table-rhythm tbody tr:nth-child(odd) td,
+.table-rhythm tbody tr:nth-child(odd) th {
+  background-color: #f9f9f9;
+}
+.table-rhythm tbody tr:hover td,
+.table-rhythm tbody tr:hover th {
+  background-color: #f5f5f5;
+}

--- a/test/fixtures/tables/table-rhythm.styl
+++ b/test/fixtures/tables/table-rhythm.styl
@@ -1,0 +1,5 @@
+relative-font-sizing = false
+.table-rhythm
+  $table(rhythm: true)
+
+relative-font-sizing = true

--- a/test/fixtures/tables/table.css
+++ b/test/fixtures/tables/table.css
@@ -13,9 +13,10 @@
 .table td {
   padding: 8px;
   line-height: 18px;
+  border-top: 1px solid;
+  border-color: #ddd;
   text-align: left;
-  vertical-align: top;
-  border-top: 1px solid #ddd;
+  vertical-align: top; 
 }
 .table th {
   font-weight: bold;

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -135,6 +135,11 @@ describe 'tables', ->
 
   it 'table-styles', (done) ->
     compile_and_match(path.join(@path, 'table.styl'), done)
+  describe 'tables with vertical rhythm', ->
+    it 'default', (done) ->
+      compile_and_match(path.join(@path, 'table-rhythm.styl'), done)
+    it 'condensed', (done) ->
+      compile_and_match(path.join(@path, 'table-rhythm-condensed.styl'), done)
 
 describe 'typography', ->
 


### PR DESCRIPTION
Hey! :)

I reviewed a little bit of vertical-rhythm mixins  and tables today. 

Fixed some bugs:
- Now offset in `-rhythm`  works as it should work, offsetting units, not lines.
- `relative-font-sizing=false` now producing correct px values (was producing incorrect rhythm and `em`)

addes some features:
- adding border to `leader/trailing/rhythm` mixins
- changing property (padding/margin) to add `borders` (with corrected offset it works like it should)
  ![image](https://cloud.githubusercontent.com/assets/2446638/4318295/00dd89c4-3f1d-11e4-923f-728d494323c8.png)
- tests for rhythm tables

but got some problems with condensed styled table:
- it works with 1 line of text, but not more (cause line-height is .5)
- text is a bit offset top (this is not so hard to fix)

![image](https://cloud.githubusercontent.com/assets/2446638/4318704/4e4ab470-3f22-11e4-9089-2c87d7f1124b.png)

what do you think guys?
