### PR TITLE
Fix #158: add missing hover-color case

### DIFF
--- a/axis/interaction.styl
+++ b/axis/interaction.styl
@@ -106,7 +106,7 @@ hover-color(color, forceUseColor = false)
       background-color: color
     else if @background-color and !forceUseColor
       background-color: color
-    else if @background-color
+    else if @background-color and !force-use-color
       background-color: color
     else if @color
       color: color


### PR DESCRIPTION
#33 introduced an update to hover-color() that I think is missing the
force-use-color parameter.

When I have a style such as:

```styl
li {
  background-color transparent // or initial, to reset a background-color from above
  hover-color red true
}
```

The result is a list item whose background swaps to red on hover,
rather than respecting the second argument of true to hover-color().

Adding a force-use-color check fixes this.