### PR TITLE
transition overriding nib

### DIFF
--- a/axis/vendor.styl
+++ b/axis/vendor.styl
@@ -6,22 +6,25 @@
 // css properties
 
 // Alias: Transition
-// 
+//
 // Transition with an intelligent default.
-// 
+//
 // ex. transition()
 // ex. transition: color 1s ease
 // ex. transition(color 1s ease, background 2.4s linear)
 
+//Cache nib transition mixin.
+_transition = transition
+
 transition()
   arguments = unquote('all .3s ease') unless arguments
-  transition: arguments
+  _transition: arguments
 
 
 // Alias: Box Shadow
-// 
+//
 // Box shadow with pie support, if you are using it.
-// 
+//
 // ex. box-shadow: 1px 1px 3px blue
 // ex. box-shadow(1px 1px 3px blue, inset 2px 0 5px rgba(0,0,0,.5))
 
@@ -30,9 +33,9 @@ box-shadow()
   pie()
 
 // Alias: Border Radius
-// 
+//
 // Border-radius with pie support, if you are using it.
-// 
+//
 // ex. +round-corners(5px)
 
 border-radius()
@@ -40,11 +43,11 @@ border-radius()
   pie()
 
 // Alias: Opacity
-// 
+//
 // I know, it seems silly. But every time you go to old IE testing you will be
 // thanking yourself for using this instead of the normal opacity declaration.
 // Overrides default opacity.
-// 
+//
 // ex. opacity: .6
 
 opacity(opacity)
@@ -58,7 +61,7 @@ border-box()
   box-sizing: border-box
 
 // Alises: background-appearance-x and y
-// 
+//
 // In case you want to use an unsupported background-position property, this
 // should set you straight!
 
@@ -69,12 +72,12 @@ background-position-y(y)
   background-position: 0 y
 
 // Mixin: Opentype ligatures
-// 
+//
 // The vast majority of fonts contain lowercase and uppercase alphabets,
 // numerals, punctuation and accents. // Many professionally-designed fonts
 // also contain ligatures, alternative characters, smallcaps, different kinds of
 // numbers, and sometimes much more besides. This enables it.
-// 
+//
 // Source: http://www.newnet-soft.com/blog/csstypography
 // Additional: http://blog.fontdeck.com/post/15777165734/opentype-1
 

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -112,6 +112,10 @@ small {
 a {
   color: #0074d9;
   text-decoration: none;
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   border-bottom: 1px solid transparent;
 }
@@ -194,6 +198,10 @@ textarea {
   color: #555;
   width: 250px;
   text-shadow: 0 0 1px rgba(255,255,255,0.1);
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
 }
 input[type='email']:focus,
@@ -378,6 +386,10 @@ textarea.error:focus {
   outline: none;
 }
 .btn {
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   font-size: 13px;
   padding: 10px 22px;
@@ -402,6 +414,10 @@ textarea.error:focus {
   background-color: #0068c3;
 }
 .btn-fancy {
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   font-size: 13px;
   padding: 10px 22px;

--- a/test/fixtures/forms/input-search.css
+++ b/test/fixtures/forms/input-search.css
@@ -11,6 +11,10 @@
   color: #555;
   width: 250px;
   text-shadow: 0 0 1px rgba(255,255,255,0.1);
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   padding-left: 9px;
   border-radius: 999px;

--- a/test/fixtures/forms/input.css
+++ b/test/fixtures/forms/input.css
@@ -11,6 +11,10 @@
   color: #555;
   width: 250px;
   text-shadow: 0 0 1px rgba(255,255,255,0.1);
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
 }
 .input:focus {

--- a/test/fixtures/typography/link.css
+++ b/test/fixtures/typography/link.css
@@ -1,6 +1,10 @@
 .link {
   color: #0074d9;
   text-decoration: none;
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   border-bottom: 1px solid transparent;
 }
@@ -16,6 +20,10 @@
 .reset-link {
   color: #0074d9;
   text-decoration: none;
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
   border-bottom: 1px solid transparent;
   border: none;

--- a/test/fixtures/vendor/transition.css
+++ b/test/fixtures/vendor/transition.css
@@ -1,6 +1,14 @@
 .transition {
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  -ms-transition: all .3s ease;
   transition: all .3s ease;
 }
 .trans-custom {
+  -webkit-transition: all 1s ease;
+  -moz-transition: all 1s ease;
+  -o-transition: all 1s ease;
+  -ms-transition: all 1s ease;
   transition: all 1s ease;
 }


### PR DESCRIPTION
Nib's vendorizing gets broken since transition gets redefined here. Cache nibs 'transition' and then call it within your newly defined transition mixin :)