### PR TITLE
Offcanvas menus

### DIFF
--- a/axis/index.styl
+++ b/axis/index.styl
@@ -14,6 +14,7 @@
 @import 'buttons'
 @import 'forms'
 @import 'tables'
+@import 'offcanvas'
 
 // ------------------------------------------
 // Framework Mixin (loads all default styles)
@@ -26,3 +27,4 @@ framework()
   buttons()
   code-blocks()
   tables()
+  offcanvas_menus()

--- a/axis/offcanvas.styl
+++ b/axis/offcanvas.styl
@@ -1,0 +1,201 @@
+// -------
+// Offcanvas
+// -------
+
+// Function: Offcanvas Menu Settings
+// 
+// Configure the offcanvas menu according to the params.
+// Params:
+//   side:  'top', 'right', 'bottom', 'left'
+//   thick:  width (left/right) or height (top/bottom) of menu
+//   show:  min-width (left/right) or min-height (top/bottom) where menu is always visible
+// 
+// ex. -offcanvas_menu_settings()
+// ex. -offcanvas_menu_settings(side: 'top', thick: 10em, show: 0)   // show:0 or show:false
+
+-offcanvas_menu_settings(side = 'left', thick = 40em, show = 80em)
+  position absolute
+  overflow-y auto
+  if side is 'left' or side is 'right'
+    width thick
+    height 100%
+    top 0
+  if side is 'top' or side is 'bottom'
+    width 100%
+    height thick
+    left 0
+  if side is 'left'
+    left 0
+    transform translate(- thick, 0)
+  if side is 'right'
+    right 0
+    transform translate(thick, 0)
+  if side is 'top'
+    top 0
+    transform translate(0, - thick)
+  if side is 'bottom'
+    bottom 0
+    transform translate(0, thick)
+  if show
+    if side is 'left' or side is 'right'
+      @media (min-width show)
+        transform translate(0,0)
+    if side is 'top' or side is 'bottom'
+      @media (min-height show)
+        transform translate(0,0)
+
+// Function: Offcanvas Content Settings
+// 
+// Configure the content element.  Parameters contain info for possible menus on all 4 sides.
+// Parameters follow css shorthand convention (top right bottom left), except all are neccessary
+//
+// Params:
+//   thick:  thickness of all 4 offcanvas menus
+//   push:   min-width/height at which menus push the content, instead of overlapping (4 values)
+//   show:   min-width/height at which menus are always visible (4 values)
+//   content:   css selector for content area
+//   open_class:  classes that parent offcanvas element will toggle for open (4 values)
+// 
+// ex. -offcanvas_content_settings()
+// ex. -offcanvas_menu_settings(thick: (0 15em 0 15em), push: (0 0em 0 0em), show: (0 0 0 0)) // always push never show
+
+-offcanvas_content_settings(thick = (0 0 0 15em), push = (0 0 0 40em), show = (0 0 0 80em), content = '.content', open_class = ('.open-top', '.open-right', '.open-bottom', '.open-left'))
+  & > {content}
+    height 100%
+    overflow-y auto
+  /* push breakpoints */
+  if push[0]
+    @media (min-height push[0])
+      &.{open_class[0]}
+        & > {content}
+          margin-top thick[0]
+        if open_class[2]
+          &:not(.{open_class[2]}) > {content}
+            height 'calc(100% - %s)' % thick[0]
+          &.{open_class[2]} > {content}
+            height 'calc(100% - %s)' % (thick[0] + thick[2])
+  if push[1]
+    @media (min-width push[1])
+      &.{open_class[1]} > {content}
+        margin-right thick[1]
+  if push[2]
+    @media (min-height push[2])
+      &.{open_class[2]}
+        & > {content}
+          margin-bottom thick[2]
+        if open_class[0]
+          &:not(.{open_class[0]}) > {content}
+            height 'calc(100% - %s)' % thick[2]
+  if push[3]
+    @media (min-width push[3])
+      &.{open_class[3]} > {content}
+        margin-left thick[3]
+
+  /* show breakpoints */
+  if show[0]
+    @media (min-height show[0])
+      & > {content}
+        margin-top thick[0]
+        if show[2] and show[2] <= show[0]
+          height 'calc(100% - %s)' % (thick[0] + thick[2])
+        else
+          height 'calc(100% - %s)' % thick[0]
+      if open_class[2]
+        &.{open_class[2]}:not(.{open_class[0]}) > {content}
+          height 'calc(100% - %s)' % (thick[0] + thick[2])
+  if show[1]
+    @media (min-width show[1])
+      & > {content}
+        margin-right thick[1]
+  if show[2]
+    @media (min-height show[2])
+      & > {content}
+        margin-bottom thick[2]
+        if show[0] and show[0] <= show[2]
+          height 'calc(100% - %s)' % (thick[0] + thick[2])
+        else
+          height 'calc(100% - %s)' % thick[2]
+      if open_class[0]
+        &.{open_class[0]}:not(.{open_class[2]}) > {content}
+          height 'calc(100% - %s)' % (thick[0] + thick[2])
+  if show[3]
+    @media (min-width show[3])
+      & > {content}
+        margin-left thick[3]
+
+
+// Mixin: Offcanvas Multi
+// 
+// Create an offcanvas element that will contain one content area and 1-4 offcanvas menus.
+// Parameters follow css shorthand convention (top right bottom left), except all are neccessary
+//
+// Params:
+//   thick:  thickness of all 4 offcanvas menus
+//   push:   min-width/height at which menus push the content, instead of overlapping (4 values)
+//   show:   min-width/height at which menus are always visible (4 values)
+//   menu:   css selectors for menus (4 values)
+//   content:   css selector for content area
+//   open_class:  classes that parent offcanvas element will toggle for open (4 values)
+// 
+// ex. offcanvas_multi()
+// ex. offcanvas_multi(thick: (10em 0 20em 0), push: (0 0 0 0), show: (0 0 80em 0), menu: ('nav' 0 '.about-us' 0), content: 'article', open_class: ('open-nav' 0 'open-about' 0))
+
+offcanvas_multi(thick = (0 0 0 15em), push = (0 0 0 40em), show = (0 0 0 80em), menu = ('.menu-top' '.menu-right' '.menu-bottom' '.menu-left'), content = '.content', open_class = ('open-top' 'open-right' 'open-bottom' 'open-left'))
+  position relative
+  overflow hidden
+  & > *
+    transition all 0.3s ease
+
+  if thick[0]
+    & > {menu[0]}
+      -offcanvas_menu_settings('top', thick[0], show[0])
+    &.{open_class[0]}
+      & > {menu[0]}
+        transform translate(0,0)
+  if thick[1]
+    & > {menu[1]}
+      -offcanvas_menu_settings('right', thick[1], show[1])
+    &.{open_class[1]}
+      & > {menu[1]}
+        transform translate(0,0)
+  if thick[2]
+    & > {menu[2]}
+      -offcanvas_menu_settings('bottom', thick[2], show[2])
+    &.{open_class[2]}
+      & > {menu[2]}
+        transform translate(0,0)
+  if thick[3]
+    & > {menu[3]}
+      -offcanvas_menu_settings('left', thick[3], show[3])
+    &.{open_class[3]}
+      & > {menu[3]}
+        transform translate(0,0)
+  
+  -offcanvas_content_settings(thick, push, show, content, open_class)
+
+
+// Mixin: Offcanvas
+// 
+// Create an offcanvas element that will contain one content area and 1 menu.
+//
+// Params:
+//   side:  'top', 'right', 'bottom', 'left'
+//   thick:  width (left/right) or height (top/bottom) of menu
+//   push:   min-width/height at which menu pushes the content, instead of overlapping
+//   show:  min-width (left/right) or min-height (top/bottom) where menu is always visible
+//   menu:   css selector for menu
+//   content:   css selector for content area
+//   open_class:  class that parent offcanvas element will toggle for open
+// 
+// ex. offcanvas()
+// ex. offcanvas(side: 'right', thick: 25em, push: 0, show: 80em, menu: 'nav', content: 'article', open: 'open')
+
+offcanvas(side = 'left', thick = 15em, push = 40em, show = 80em, menu = ".menu-left", content = ".content", open_class = "open")
+  if side is 'top'
+    offcanvas_multi(thick: (thick 0 0 0), push: (push 0 0 0), show: (show 0 0 0), menu: (menu 0 0 0), content: content, open_class: (open_class 0 0 0))
+  if side is 'right'
+    offcanvas_multi(thick: (0 thick 0 0), push: (0 push 0 0), show: (0 show 0 0), menu: (0 menu 0 0), content: content, open_class: (0 open_class 0 0))
+  if side is 'bottom'
+    offcanvas_multi(thick: (0 0 thick 0), push: (0 0 push 0), show: (0 0 show 0), menu: (0 0 menu 0), content: content, open_class: (0 0 open_class 0))
+  if side is 'left'
+    offcanvas_multi(thick: (0 0 0 thick), push: (0 0 0 push), show: (0 0 0 show), menu: (0 0 0 menu), content: content, open_class: (0 0 0 open_class))

--- a/axis/offcanvas.styl
+++ b/axis/offcanvas.styl
@@ -199,3 +199,19 @@ offcanvas(side = 'left', thick = 15em, push = 40em, show = 80em, menu = ".menu-l
     offcanvas_multi(thick: (0 0 thick 0), push: (0 0 push 0), show: (0 0 show 0), menu: (0 0 menu 0), content: content, open_class: (0 0 open_class 0))
   if side is 'left'
     offcanvas_multi(thick: (0 0 0 thick), push: (0 0 0 push), show: (0 0 0 show), menu: (0 0 0 menu), content: content, open_class: (0 0 0 open_class))
+
+
+// Additive Mixin: Offcanvas Menus
+// 
+// WARNING: Creates classes in your css and styles them - not to be used inside
+// an element.
+// 
+// This mixin makes it such that you can use classes to define offcanvas menus.
+// - .offcanvas - creates an offcanvas container
+// - .menu-(top/right/bottom/left) - creates an offcanvas menu
+// - .content - creates a content area for the offcanvs menu
+//   .open-(top/right/bottom/left) - toggles the corresponding menu open/close when placed on offcanvas container.
+
+offcanvas_menus()
+  .offcanvas
+    offcanvas_multi(thick: (15em 15em 15em 15em), push: (40em 30em 40em 30em), show: (0 80em 0 80em))

--- a/axis/offcanvas.styl
+++ b/axis/offcanvas.styl
@@ -8,7 +8,7 @@
 // Params:
 //   side:  'top', 'right', 'bottom', 'left'
 //   thick:  width (left/right) or height (top/bottom) of menu
-//   show:  min-width (left/right) or min-height (top/bottom) where menu is always visible
+//   show:   min-width (left/right) or min-height (top/bottom) where menu is always visible
 // 
 // ex. -offcanvas_menu_settings()
 // ex. -offcanvas_menu_settings(side: 'top', thick: 10em, show: 0)   // show:0 or show:false
@@ -59,11 +59,11 @@
 // ex. -offcanvas_content_settings()
 // ex. -offcanvas_menu_settings(thick: (0 15em 0 15em), push: (0 0em 0 0em), show: (0 0 0 0)) // always push never show
 
--offcanvas_content_settings(thick = (0 0 0 15em), push = (0 0 0 40em), show = (0 0 0 80em), content = '.content', open_class = ('.open-top', '.open-right', '.open-bottom', '.open-left'))
+-offcanvas_content_settings(thick = (0 0 0 15em), push = (0 0 0 40em), show = (0 0 0 80em), content = '.content', open_class = ('.open-top' '.open-right' '.open-bottom' '.open-left'))
   & > {content}
     height 100%
     overflow-y auto
-  /* push breakpoints */
+
   if push[0]
     @media (min-height push[0])
       &.{open_class[0]}
@@ -91,7 +91,6 @@
       &.{open_class[3]} > {content}
         margin-left thick[3]
 
-  /* show breakpoints */
   if show[0]
     @media (min-height show[0])
       & > {content}
@@ -182,7 +181,7 @@ offcanvas_multi(thick = (0 0 0 15em), push = (0 0 0 40em), show = (0 0 0 80em), 
 //   side:  'top', 'right', 'bottom', 'left'
 //   thick:  width (left/right) or height (top/bottom) of menu
 //   push:   min-width/height at which menu pushes the content, instead of overlapping
-//   show:  min-width (left/right) or min-height (top/bottom) where menu is always visible
+//   show:   min-width (left/right) or min-height (top/bottom) where menu is always visible
 //   menu:   css selector for menu
 //   content:   css selector for content area
 //   open_class:  class that parent offcanvas element will toggle for open

--- a/test/additive.html
+++ b/test/additive.html
@@ -55,6 +55,25 @@
         <td>doge</td>
       </tr>
     </table>
+    <div class="offcanvas">
+      <div class="menu-left">Left</div>
+      <div class="menu-right">Right</div>
+      <div class="menu-top">Top</div>
+      <div class="menu-bottom">Bottom</div>
+      <div class="content">
+        <div class="btn" data-toggle="left">Left</div>
+        <div class="btn" data-toggle="right">Right</div>
+        <div class="btn" data-toggle="top">Top</div>
+        <div class="btn" data-toggle="bottom">Bottom</div>
+      </div>
+    </div>
+
+    <script>
+      document.querySelector('.offcanvas').addEventListener('click', function (e) {
+        var side = e.target.getAttribute('data-toggle');
+        this.classList.toggle('open-' + side);
+      });
+    </script>
   </body>
 
 </html>

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -561,3 +561,155 @@ table tbody tr:hover td,
 table tbody tr:hover th {
   background-color: #f5f5f5;
 }
+.offcanvas {
+  position: relative;
+  overflow: hidden;
+}
+.offcanvas > * {
+  -webkit-transition: all 0.3s ease;
+  -moz-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
+  -ms-transition: all 0.3s ease;
+  transition: all 0.3s ease;
+}
+.offcanvas > .menu-top {
+  position: absolute;
+  overflow-y: auto;
+  width: 100%;
+  height: 15em;
+  left: 0;
+  top: 0;
+  -webkit-transform: translate(0, -15em);
+  -moz-transform: translate(0, -15em);
+  -o-transform: translate(0, -15em);
+  -ms-transform: translate(0, -15em);
+  transform: translate(0, -15em);
+}
+.offcanvas.open-top > .menu-top {
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.offcanvas > .menu-right {
+  position: absolute;
+  overflow-y: auto;
+  width: 15em;
+  height: 100%;
+  top: 0;
+  right: 0;
+  -webkit-transform: translate(15em, 0);
+  -moz-transform: translate(15em, 0);
+  -o-transform: translate(15em, 0);
+  -ms-transform: translate(15em, 0);
+  transform: translate(15em, 0);
+}
+@media (min-width: 80em) {
+  .offcanvas > .menu-right {
+    -webkit-transform: translate(0, 0);
+    -moz-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    transform: translate(0, 0);
+  }
+}
+.offcanvas.open-right > .menu-right {
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.offcanvas > .menu-bottom {
+  position: absolute;
+  overflow-y: auto;
+  width: 100%;
+  height: 15em;
+  left: 0;
+  bottom: 0;
+  -webkit-transform: translate(0, 15em);
+  -moz-transform: translate(0, 15em);
+  -o-transform: translate(0, 15em);
+  -ms-transform: translate(0, 15em);
+  transform: translate(0, 15em);
+}
+.offcanvas.open-bottom > .menu-bottom {
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.offcanvas > .menu-left {
+  position: absolute;
+  overflow-y: auto;
+  width: 15em;
+  height: 100%;
+  top: 0;
+  left: 0;
+  -webkit-transform: translate(-15em, 0);
+  -moz-transform: translate(-15em, 0);
+  -o-transform: translate(-15em, 0);
+  -ms-transform: translate(-15em, 0);
+  transform: translate(-15em, 0);
+}
+@media (min-width: 80em) {
+  .offcanvas > .menu-left {
+    -webkit-transform: translate(0, 0);
+    -moz-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    transform: translate(0, 0);
+  }
+}
+.offcanvas.open-left > .menu-left {
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.offcanvas > .content {
+  height: 100%;
+  overflow-y: auto;
+}
+@media (min-height: 40em) {
+  .offcanvas.open-top > .content {
+    margin-top: 15em;
+  }
+  .offcanvas.open-top:not(.open-bottom) > .content {
+    height: calc(100% - 15em);
+  }
+  .offcanvas.open-top.open-bottom > .content {
+    height: calc(100% - 30em);
+  }
+}
+@media (min-width: 30em) {
+  .offcanvas.open-right > .content {
+    margin-right: 15em;
+  }
+}
+@media (min-height: 40em) {
+  .offcanvas.open-bottom > .content {
+    margin-bottom: 15em;
+  }
+  .offcanvas.open-bottom:not(.open-top) > .content {
+    height: calc(100% - 15em);
+  }
+}
+@media (min-width: 30em) {
+  .offcanvas.open-left > .content {
+    margin-left: 15em;
+  }
+}
+@media (min-width: 80em) {
+  .offcanvas > .content {
+    margin-right: 15em;
+  }
+}
+@media (min-width: 80em) {
+  .offcanvas > .content {
+    margin-left: 15em;
+  }
+}

--- a/test/fixtures/offcanvas/offcanvas.css
+++ b/test/fixtures/offcanvas/offcanvas.css
@@ -1,0 +1,54 @@
+.offcanvas-menu {
+  position: relative;
+  overflow: hidden;
+}
+.offcanvas-menu > * {
+  -webkit-transition: all 0.3s ease;
+  -moz-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
+  -ms-transition: all 0.3s ease;
+  transition: all 0.3s ease;
+}
+.offcanvas-menu > .menu-left {
+  position: absolute;
+  overflow-y: auto;
+  width: 15em;
+  height: 100%;
+  top: 0;
+  left: 0;
+  -webkit-transform: translate(-15em, 0);
+  -moz-transform: translate(-15em, 0);
+  -o-transform: translate(-15em, 0);
+  -ms-transform: translate(-15em, 0);
+  transform: translate(-15em, 0);
+}
+@media (min-width: 80em) {
+  .offcanvas-menu > .menu-left {
+    -webkit-transform: translate(0, 0);
+    -moz-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    transform: translate(0, 0);
+  }
+}
+.offcanvas-menu.open > .menu-left {
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.offcanvas-menu > .content {
+  height: 100%;
+  overflow-y: auto;
+}
+@media (min-width: 40em) {
+  .offcanvas-menu.open > .content {
+    margin-left: 15em;
+  }
+}
+@media (min-width: 80em) {
+  .offcanvas-menu > .content {
+    margin-left: 15em;
+  }
+}

--- a/test/fixtures/offcanvas/offcanvas.styl
+++ b/test/fixtures/offcanvas/offcanvas.styl
@@ -1,0 +1,2 @@
+.offcanvas-menu
+  offcanvas()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -279,4 +279,11 @@ describe 'additive', ->
   it 'framework', (done) ->
     compile_and_match(path.join(@path, 'framework.styl'), done)
 
+describe 'offcanvas', ->
+
+  before -> @path = path.join(test_path, 'offcanvas')
+
+  it 'offcanvas', (done) ->
+    compile_and_match(path.join(@path, 'offcanvas.styl'), done)
+
 # describe 'vertical-rhythm'

--- a/test/visual.html
+++ b/test/visual.html
@@ -79,6 +79,9 @@
     <link rel='stylesheet' href='fixtures/utilities/triangle.css' >
     <link rel='stylesheet' href='fixtures/utilities/vertical-align.css' >
 
+    <!-- offcanvas -->
+    <link rel="stylesheet" href="fixtures/offcanvas/offcanvas.css">
+
     <style>
       body {
         font-family: sans-serif;
@@ -113,6 +116,13 @@
         margin: 1em 0;
         width: 400px;
         height: 50px;
+      }
+      .offcanvas-menu {
+        height: 200px;
+        border: 4px solid #000;
+      }
+      .offcanvas-menu .menu-left {
+        background: #d8d8d8;
       }
     </style>
   </head>
@@ -386,6 +396,24 @@
       </div>
 
     </section>
+
+    <section>
+      <div class="offcanvas-menu">
+        <div class="menu-left">Left Menu</div>
+        <div class="content">
+          <p>Narrow browser window to show/hide menu.</p>
+          <button class="button">Toggle Menu</button>
+        </div>
+      </div>
+    </section>
+
+    <script>
+      document.querySelector('.offcanvas-menu').addEventListener('click', function (e) {
+        if (e.target.tagName === "BUTTON") {
+          this.classList.toggle('open');
+        }
+      });
+    </script>
 
   </body>
 


### PR DESCRIPTION
These mixins allow you to create an element with offcanvas menus and a content area.  Each offcanvas container can have 1-4 menus and 1 content area.  All parameters have defaults, but are configurable.

Mixins:
offcanvas()  -  creates an area with 1 menu and 1 content area (uses offcanvas_multi behind the scenes)
offcanvas_multi()  -  container with 1-4 menus and 1 content area

Additive Mixin:
offcanvas_menus()  -  creates classes for creating offcanvas menus

There is currently no default styling.  I also added script tags to the test pages to toggle the open classes.