### PR TITLE
Opacity args

### DIFF
--- a/axis/vendor.styl
+++ b/axis/vendor.styl
@@ -50,8 +50,13 @@ border-radius()
 //
 // ex. opacity: .6
 
-opacity(opacity, args...)  
-  filter: s("progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)", opacity * 100 args) if support-for-ie  
+opacity(opacity, args...)
+  
+  if args  
+    filter: s("progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)", opacity * 100 args) if support-for-ie  
+  else
+    filter: s("progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)", opacity * 100) if support-for-ie  
+    
   opacity: opacity args
 
 // Alias: Border Box

--- a/axis/vendor.styl
+++ b/axis/vendor.styl
@@ -50,9 +50,9 @@ border-radius()
 //
 // ex. opacity: .6
 
-opacity(opacity)
-  filter: s("progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)", opacity * 100) if support-for-ie
-  opacity: opacity
+opacity(opacity, args...)  
+  filter: s("progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)", opacity * 100 args) if support-for-ie  
+  opacity: opacity args
 
 // Alias: Border Box
 // A quicker way to specify border-box sizing.

--- a/test/fixtures/vendor/opacity.css
+++ b/test/fixtures/vendor/opacity.css
@@ -5,3 +5,10 @@
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50);
   opacity: 0.5;
 }
+.opacity {
+  opacity: 0.5 !important;
+}
+.opacity-ie {
+  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50 !important);
+  opacity: 0.5 !important;
+}

--- a/test/fixtures/vendor/opacity.styl
+++ b/test/fixtures/vendor/opacity.styl
@@ -6,3 +6,12 @@ support-for-ie = true
   opacity: .5
 
 support-for-ie = false
+
+.opacity
+  opacity: .5 !important
+
+support-for-ie = true
+.opacity-ie
+  opacity: .5 !important
+
+support-for-ie = false


### PR DESCRIPTION
Adds optional arguments for opacity. Essentially just to fill the case of using `!important`.

Fixes #167 