### PR TITLE
adds no-select() and adjusts the color tolerance of buttons

### DIFF
--- a/axis/buttons.styl
+++ b/axis/buttons.styl
@@ -46,7 +46,7 @@
 button($color = $default-color, $size = "medium", $text-color = null)
 
   // color detection and changes
-  $text-color = (light($color) ? #494949 : #fff) unless $text-color
+  $text-color = (light(darken($color, 22%)) ? rgba(#000, .7) : #fff) unless $text-color
   $parsed-size = -parse($size)
 
   // now that we've got numbers, let's work some proportions
@@ -68,7 +68,9 @@ button($color = $default-color, $size = "medium", $text-color = null)
   text-align: center
   text-decoration: none
   display: inline-block
-  border none
+  border: none
+  no-select()
+
   &:hover, &:focus
     background-color: darken($color, 5%)
     color: darken($text-color, 3%)
@@ -103,8 +105,8 @@ glossy-button($color = $default-color, $size = "medium", $text-color = null, $sh
   if $text-color
     $dark-text = light($text-color) ? true : false
   else
-    $dark-text = light($color) ? false : true
-    $text-color = $dark-text ? white : #494949
+    $dark-text = light(darken($color, 22%)) ? false : true
+    $text-color = $dark-text ? white : rgba(#000, .7)
 
   $shadow-color = $dark-text ? rgba(#000,.1) : rgba(#fff,.3) unless $shadow-color
   $hover-color = $dark-text ? rgba(#000,.2) : rgba(#fff,.5) unless $hover-color
@@ -135,6 +137,7 @@ glossy-button($color = $default-color, $size = "medium", $text-color = null, $sh
   text-align: center
   text-decoration: none
   display: inline-block
+  no-select()
 
   &:hover, &:focus
     background-position: 0 unit($height * -1, 'px')

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -392,6 +392,11 @@ textarea.error:focus {
   text-decoration: none;
   display: inline-block;
   border: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 .btn:hover,
 .btn:focus {
@@ -422,6 +427,11 @@ textarea.error:focus {
   text-align: center;
   text-decoration: none;
   display: inline-block;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 .btn-fancy:hover,
 .btn-fancy:focus {

--- a/test/fixtures/buttons/button.css
+++ b/test/fixtures/buttons/button.css
@@ -12,6 +12,11 @@
   text-decoration: none;
   display: inline-block;
   border: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 .button:hover,
 .button:focus {

--- a/test/fixtures/buttons/glossy-button.css
+++ b/test/fixtures/buttons/glossy-button.css
@@ -16,6 +16,11 @@
   text-align: center;
   text-decoration: none;
   display: inline-block;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 .glossy-button:hover,
 .glossy-button:focus {


### PR DESCRIPTION
Buttons have a nice color tolerance tolerance level now. Here's some example button before and afters:

![buttons](https://cloud.githubusercontent.com/assets/296130/10183439/5dd78a8e-66f5-11e5-94bb-156e3ec51a70.png)
