### PR TITLE
only style default links that do not have a class

### DIFF
--- a/axis/typography.styl
+++ b/axis/typography.styl
@@ -515,7 +515,7 @@ typography()
   small
     small()
 
-  a
+  a[href]:not([class])
     link()
 
   blockquote

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -109,20 +109,20 @@ small {
   opacity: 0.6;
   font-weight: normal;
 }
-a {
+a[href]:not([class]) {
   color: #0074d9;
   text-decoration: none;
   -webkit-transition: all .3s ease;
           transition: all .3s ease;
   border-bottom: 1px solid transparent;
 }
-a:hover {
+a[href]:not([class]):hover {
   border-bottom: 1px solid;
 }
-a:hover {
+a[href]:not([class]):hover {
   color: #0063b8;
 }
-a:visited {
+a[href]:not([class]):visited {
   opacity: 0.8;
 }
 blockquote {

--- a/test/fixtures/interaction/click-down.css
+++ b/test/fixtures/interaction/click-down.css
@@ -1,5 +1,4 @@
 .click-down:active {
   -webkit-transform: translateY(1px);
-      -ms-transform: translateY(1px);
           transform: translateY(1px);
 }

--- a/test/fixtures/interaction/click-shrink.css
+++ b/test/fixtures/interaction/click-shrink.css
@@ -1,5 +1,4 @@
 .click-shrink:active {
   -webkit-transform: scale(0.92);
-      -ms-transform: scale(0.92);
           transform: scale(0.92);
 }

--- a/test/fixtures/interaction/hover-float.css
+++ b/test/fixtures/interaction/hover-float.css
@@ -16,12 +16,10 @@
 }
 .hover-float:hover {
   -webkit-transform: translateY(-7px);
-      -ms-transform: translateY(-7px);
           transform: translateY(-7px);
 }
 .hover-float:hover:before {
   opacity: 1;
   -webkit-transform: scale(1);
-      -ms-transform: scale(1);
           transform: scale(1);
 }

--- a/test/fixtures/interaction/hover-pop.css
+++ b/test/fixtures/interaction/hover-pop.css
@@ -2,6 +2,5 @@
   position: relative;
   z-index: 10;
   -webkit-transform: scale(1.2);
-      -ms-transform: scale(1.2);
           transform: scale(1.2);
 }

--- a/test/fixtures/layout/vertical-align.css
+++ b/test/fixtures/layout/vertical-align.css
@@ -8,13 +8,11 @@
   position: relative;
   top: 50%;
   -webkit-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
           transform: translateY(-50%);
 }
 .vertical-align .inner-div.reset {
   position: relative;
   top: 0;
   -webkit-transform: translateY(0);
-      -ms-transform: translateY(0);
           transform: translateY(0);
 }

--- a/test/fixtures/ui/icon-arrow.css
+++ b/test/fixtures/ui/icon-arrow.css
@@ -11,7 +11,6 @@
   width: 25px;
   margin-left: 1%;
   -webkit-transform: rotate(45deg) translateX(4px) translateY(4px);
-      -ms-transform: rotate(45deg) translateX(4px) translateY(4px);
           transform: rotate(45deg) translateX(4px) translateY(4px);
 }
 .icon-arrow-left {
@@ -27,6 +26,5 @@
   width: 25px;
   margin-left: 1%;
   -webkit-transform: rotate(-135deg) translateX(-12px) translateY(4px);
-      -ms-transform: rotate(-135deg) translateX(-12px) translateY(4px);
           transform: rotate(-135deg) translateX(-12px) translateY(4px);
 }

--- a/test/fixtures/ui/icon-x.css
+++ b/test/fixtures/ui/icon-x.css
@@ -15,11 +15,9 @@
   height: 1px;
   background: #888;
   -webkit-transform: rotate(45deg);
-      -ms-transform: rotate(45deg);
           transform: rotate(45deg);
 }
 .icon-x:after {
   -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
           transform: rotate(-45deg);
 }


### PR DESCRIPTION
Currently when `typography` additive mixin is called **all** `a` tags are given then `link` mixin. This gets inherited to any future `a` styling, which is often unwanted (ie `a.btn` getting a bottom border on hover). 

This change applies the default `link` style only to `a` tags that do **not** have a style.

[see example](http://codepen.io/dbox/pen/pggJxW) 