### PR TITLE
Make clearfix alias a method

### DIFF
--- a/axis/layout.styl
+++ b/axis/layout.styl
@@ -11,7 +11,8 @@ group()
 
 // Alias: clearfix
 // Group with a worse name. If you need really can't break the habit.
-clearfix = group
+clearfix()
+  group()
 
 // Function: pos
 // Backs position helpers, found below


### PR DESCRIPTION
Make clearfix alias a method. This is to avoid rewriting occurrences of the text `clearfix` to `group` when it is not called as a method anyhow - which as far as I can see is the only valid way to use clearfix. See issue https://github.com/jenius/axis/issues/263

Doing this ease usage alongside other libraries that also use `clearfix`.

This, by the way, is my first pull request ever.