### PR TITLE
fix stack name

### DIFF
--- a/axis/settings.styl
+++ b/axis/settings.styl
@@ -6,7 +6,7 @@
 $helvetica-neue = "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif
 $helvetica = "Helvetica Neue", Helvetica, Arial, sans-serif
 $georgia = Georgia, Cambria, "Times New Roman", Times, serif
-$lucidia-grande = "Lucida Grande", Tahoma, Verdana, Arial, sans-serif
+$lucida-grande = "Lucida Grande", Tahoma, Verdana, Arial, sans-serif
 $monospace = unquote("'Bitstream Vera Sans Mono', Consolas, Courier, monospace")
 $verdana = Verdana, Geneva, sans-serif
 


### PR DESCRIPTION
The `$lucidia-grande` font stack should be called `$lucida-grande`. It also seems to be incorrect in the official docs. HTH